### PR TITLE
GuardDuty enabler: prevent error on every lambda invocation

### DIFF
--- a/src/guardduty_enabler.py
+++ b/src/guardduty_enabler.py
@@ -531,3 +531,4 @@ def lambda_handler(event, context):
                 json.dumps(failed_accounts, sort_keys=True, default=str)))
     except Exception as e:
         LOGGER.error("Exception: %s" % (str(e)))
+        send(event, context, 'FAILED', {})

--- a/src/guardduty_enabler.py
+++ b/src/guardduty_enabler.py
@@ -25,7 +25,6 @@ import os
 import time
 import logging
 import urllib3
-import cfnresponse
 from botocore.exceptions import ClientError
 
 LOGGER = logging.getLogger()
@@ -528,8 +527,7 @@ def lambda_handler(event, context):
                         LOGGER.debug(f"Finished {account} in {aws_region}")
 
         if len(failed_accounts) > 0:
-            LOGGER.info("Error Processing following accounts: %s" % (
+            LOGGER.error("Error Processing following accounts: %s" % (
                 json.dumps(failed_accounts, sort_keys=True, default=str)))
-        cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
-    except Exception:
-        cfnresponse.send(event, context, cfnresponse.FAILED, {})
+    except Exception as e:
+        LOGGER.error("Exception: %s" % (str(e)))

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,1 @@
 boto3
-cfnresponse


### PR DESCRIPTION
The GuardDuty enabler throws an error every time it is invoked:

```
[ERROR] AttributeError: module 'cfnresponse' has no attribute 'send'
Traceback (most recent call last):
  File "/var/task/guardduty_enabler.py", line 535, in lambda_handler
    cfnresponse.send(event, context, cfnresponse.FAILED, {})
```

The issue is that it isn't supported (anymore?) the way we are trying to package it into a zip file in an S3 bucket:

AWS make a point that:
```
Note
The cfn-response module is available only when you use the ZipFile property to write your source code. 
It isn't available for source code that's stored in Amazon S3 buckets. 
For code in buckets, you must write your own functions to send responses.
```
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-lambda-function-code-cfnresponsemodule.html

The code is too big to put in an inline CF ZipFile.

I tested the `exception as e` line by adding `1/0` in the code, and it displayed the error in the CloudWatch logs as expected.
 

While I was making a change I changed one of the ERROR messages to LOGGING.error, as we run the Lambda with ERROR logging set, but actual errors are only logged to INFO.
